### PR TITLE
Use online streamStatus for Generic collection

### DIFF
--- a/CommandCollections.xml
+++ b/CommandCollections.xml
@@ -194,6 +194,6 @@
 			<name>Generic</name>
 			<name>Online</name>
 		</commandLists>
-		<streamStatus>any</streamStatus>
+		<streamStatus>online</streamStatus>
 	</commandCollection>
 </commandCollections>


### PR DESCRIPTION
Since command collection "Generic" contains command list
`Online.xml`, it makes sense to limit its application only to
online streams. This shouldn't be a functional change, since
command collection "Offline" is defined earlier in the list of
command collections, but it's better not to rely on it anyway
and be more explicit with when command collection "Generic"
is supposed to be used.

So use streamStatus `online` in command collection "Generic".